### PR TITLE
Ignore all punctuation when sorting

### DIFF
--- a/indexed_collation/__init__.py
+++ b/indexed_collation/__init__.py
@@ -73,8 +73,8 @@ class IndexedCollation:
 
     def transformed_for_sorting(self, obj, key=None):
         value = key(obj) if key else obj
-        # Strip leading punctuation for sorting
-        value = re.sub(r'^\W+', '', value, flags=re.UNICODE)
+        # Strip punctuation for sorting
+        value = re.sub(r'[^\w\s]+', '', value, flags=re.UNICODE)
         return value
 
     def key_for_sorting(self, obj, key=None):


### PR DESCRIPTION
Previously, leading punctuation was ignored when sorting, like the apostrophe in ’Tis – this change makes it so all punctuation is ignored when sorting. All punctuation being ignored lines up more closely with index sorting in the printed book (Hymns).